### PR TITLE
Avoid create autocomplete object twice

### DIFF
--- a/src/lib/angular-google-place/directives/angular-google-place.directive.ts
+++ b/src/lib/angular-google-place/directives/angular-google-place.directive.ts
@@ -83,7 +83,7 @@ export class AngularGooglePlaceDirective implements OnInit {
    @Output() transit_station: EventEmitter<any>  = new EventEmitter();
    */
 
-  autocomplete: any;
+  autocomplete: any = null;
 
   trigger: any;
 
@@ -115,22 +115,23 @@ export class AngularGooglePlaceDirective implements OnInit {
 
 
   setAutocompleteAndInvokeEvent(options: any) {
-    this.autocomplete = new google.maps.places.Autocomplete(this.el.nativeElement, options);
-    this.trigger = this.autocomplete.addListener('place_changed', () => {
-      this.ngZone.run(() => {
-        console.log('ngZone.run');
-        this.place = this.autocomplete.getPlace();
-        console.log(this.place);
-        if (this.place && this.place.place_id) {
-          this.invokeEvent();
-        }
+    if(this.autocomplete === null) {
+      this.autocomplete = new google.maps.places.Autocomplete(this.el.nativeElement, options);
+      this.trigger = this.autocomplete.addListener('place_changed', () => {
+        this.ngZone.run(() => {
+          this.place = this.autocomplete.getPlace();
+          if (this.place && this.place.place_id) {
+            this.invokeEvent();
+          }
+        });
       });
-    });
+    } else {
+      this.autocomplete.setOptions(options);
+    }
   }
 
 
   invokeEvent() {
-    console.log('invokeEvent');
     this.setAddress.emit(this.place);
 
     const street_number = this.service.street_number(this.place.address_components);


### PR DESCRIPTION
Create object autocomplete only if was not created before.
Change the options if autocomplete already exists.